### PR TITLE
Add `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @CDCgov/dibbs-ecr-diff-engineering


### PR DESCRIPTION
This adds @CDCgov/dibbs-ecr-diff-engineering as the CODEOWNERs to make PR reviews a little simpler moving forward.