### PR TITLE
Add workflow for unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Run tests
+
+on:
+  workflow_dispatch
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install the project
+        run: uv sync --all-packages --locked --all-extras --dev
+
+      - name: Run unit tests
+        shell: bash
+        run: |
+          uv run pytest


### PR DESCRIPTION
## Related Issue

- Resolves #6 

## Changes Proposed

- Adds workflow to run tests

## Additional Information

- PRs are **not** currently configured to run this workflow yet

## Testing

- You can use [act to test the Github Actions locally](https://nektosact.com/introduction.html), just note that you'll need to pass it a personal access token (recommend setting a fine-grained token to read only public repositories)

```
act -s GITHUB_TOKEN
(note that GITHUB_TOKEN is a string literal, NOT a placeholder for your token. You will be prompted to securely input your token after entering the above command)
```

Successful job run with `act`
<img width="463" height="155" alt="image" src="https://github.com/user-attachments/assets/33227805-3911-4366-9b71-5c7fce33d592" />

## Checklist for Primary Reviewer

- [ ] Any large-scale changes have been deployed and smoke tested
- [ ] Any content updates (user-facing error messages, etc) have been approved by content team
- [ ] Any dependencies introduced have been vetted and discussed